### PR TITLE
feat: Persist theme setting across sessions

### DIFF
--- a/Helpers/ThemeManager.cs
+++ b/Helpers/ThemeManager.cs
@@ -1,0 +1,32 @@
+using Microsoft.UI.Xaml;
+using Windows.Storage;
+
+namespace ToolX.Helpers
+{
+    public static class ThemeManager
+    {
+        private const string ThemeSettingName = "AppTheme";
+
+        public static void ApplyTheme(ElementTheme theme)
+        {
+            if (MainWindow.m_window.Content is FrameworkElement rootElement)
+            {
+                rootElement.RequestedTheme = theme;
+            }
+        }
+
+        public static void SaveTheme(ElementTheme theme)
+        {
+            ApplicationData.Current.LocalSettings.Values[ThemeSettingName] = (int)theme;
+        }
+
+        public static ElementTheme LoadTheme()
+        {
+            if (ApplicationData.Current.LocalSettings.Values.TryGetValue(ThemeSettingName, out var themeValue) && themeValue is int themeInt)
+            {
+                return (ElementTheme)themeInt;
+            }
+            return ElementTheme.Default; // Default theme
+        }
+    }
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
+using ToolX.Helpers;
 
 namespace ToolX
 {
@@ -13,6 +14,10 @@ namespace ToolX
             this.InitializeComponent();
             m_window = this;
             this.Title = "ToolX - Image & Video Toolkit";
+
+            // Apply the saved theme
+            var savedTheme = ThemeManager.LoadTheme();
+            ThemeManager.ApplyTheme(savedTheme);
 
             // Set Icons using C# code for reliability
             HomeNavItem.Icon = new SymbolIcon(Symbol.Home);

--- a/SettingsPage.xaml.cs
+++ b/SettingsPage.xaml.cs
@@ -1,5 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using ToolX.Helpers;
 
 namespace ToolX
 {
@@ -11,47 +12,44 @@ namespace ToolX
             this.Loaded += SettingsPage_Loaded;
         }
 
-        // This method runs when the page is loaded, ensuring the correct radio button is selected.
         private void SettingsPage_Loaded(object sender, RoutedEventArgs e)
         {
-            if (this.XamlRoot.Content is FrameworkElement rootElement)
+            var currentTheme = ThemeManager.LoadTheme();
+            switch (currentTheme)
             {
-                switch (rootElement.RequestedTheme)
-                {
-                    case ElementTheme.Light:
-                        ThemeRadioButtons.SelectedIndex = 0;
-                        break;
-                    case ElementTheme.Dark:
-                        ThemeRadioButtons.SelectedIndex = 1;
-                        break;
-                    case ElementTheme.Default:
-                        ThemeRadioButtons.SelectedIndex = 2;
-                        break;
-                }
+                case ElementTheme.Light:
+                    ThemeRadioButtons.SelectedIndex = 0;
+                    break;
+                case ElementTheme.Dark:
+                    ThemeRadioButtons.SelectedIndex = 1;
+                    break;
+                case ElementTheme.Default:
+                    ThemeRadioButtons.SelectedIndex = 2;
+                    break;
             }
         }
 
-        // This method runs when the user selects a new theme.
         private void ThemeRadioButtons_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (e.AddedItems.Count > 0)
             {
-                var selectedTheme = (e.AddedItems[0] as RadioButton)?.Content?.ToString();
-                if (this.XamlRoot.Content is FrameworkElement rootElement)
+                var selectedThemeName = (e.AddedItems[0] as RadioButton)?.Content?.ToString();
+                ElementTheme newTheme;
+                switch (selectedThemeName)
                 {
-                    switch (selectedTheme)
-                    {
-                        case "Light":
-                            rootElement.RequestedTheme = ElementTheme.Light;
-                            break;
-                        case "Dark":
-                            rootElement.RequestedTheme = ElementTheme.Dark;
-                            break;
-                        case "Use system setting":
-                            rootElement.RequestedTheme = ElementTheme.Default;
-                            break;
-                    }
+                    case "Light":
+                        newTheme = ElementTheme.Light;
+                        break;
+                    case "Dark":
+                        newTheme = ElementTheme.Dark;
+                        break;
+                    default:
+                        newTheme = ElementTheme.Default;
+                        break;
                 }
+
+                ThemeManager.ApplyTheme(newTheme);
+                ThemeManager.SaveTheme(newTheme);
             }
         }
     }

--- a/ToolX.csproj
+++ b/ToolX.csproj
@@ -73,6 +73,12 @@
     </Page>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Helpers\ThemeManager.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+
   <!--
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution
     Explorer "Package and Publish" context menu entry to be enabled for this project even if


### PR DESCRIPTION
I've implemented a `ThemeManager` to save your selected theme (Light, Dark, or System Default) to local application settings.

- Your chosen theme is now loaded and applied at application startup.
- The settings page now correctly reflects the saved theme and updates it when changed.
- This ensures that your theme preference is maintained across application sessions.